### PR TITLE
Adds support for Yarn < 1.1.0

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -33,14 +33,20 @@ module.exports = function(
   const appPackage = require(path.join(appPath, 'package.json'));
   const useYarn = fs.existsSync(path.join(appPath, 'yarn.lock'));
 
-  const templatePath = templateBuilder.getTemplatePath(
-    template,
-    appName,
-    ownPath,
-    originalDirectory,
-    useYarn,
-    verbose
-  );
+  let templatePath;
+  try {
+    templatePath = templateBuilder.getTemplatePath(
+      template,
+      appName,
+      ownPath,
+      originalDirectory,
+      useYarn,
+      verbose
+    );
+  } catch (error) {
+    console.error(error.message);
+    return;
+  }
 
   if (!templatePath) {
     console.error(
@@ -177,6 +183,8 @@ module.exports = function(
       return;
     }
   }
+
+  templateBuilder.cleanup(originalDirectory);
 
   // Display the most elegant way to cd.
   // This needs to handle an undefined originalDirectory for


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Removes dependency on the `yarn global dir` command which only became available in Yarn v1.1.0 😸

Instead of finding the global install dir, the template to be used is now saved to a temporary directory that is removed once the new app has been bootstrapped.

Other changes include better error output if problems occur during the template fetch process.
